### PR TITLE
Update to deis base v0.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/deis/base:v0.3.5
+FROM quay.io/deis/base:v0.3.6


### PR DESCRIPTION
v0.3.6 removed [v0.3.5's High vulnerability](https://quay.io/repository/deis/base/image/98db27d5928dd007954d05f500f40ed5b1b8a5e3b8397ff874e55b5e1203ad79?tab=vulnerabilities), leaving [14 medium vulnerabilities](https://quay.io/repository/deis/base/image/e86ad361b08d8b60c86d7c062d949d5c121b69efb4ef9eaeca49fc4a4bbcb7e4?tab=vulnerabilities). Red to orange!